### PR TITLE
Fix core glossary title typos

### DIFF
--- a/rdf/glossaries/core/core-glossary.ttl
+++ b/rdf/glossaries/core/core-glossary.ttl
@@ -21,7 +21,7 @@
 #################################################################
 <https://w3id.org/schweidler/semantics/qa-kg/core-glossary>
     a owl:Ontology ;
-    dct:title "Software Qualtiy Assurrance Domain Core Glossary" ;
+    dct:title "Software Quality Assurance Domain Core Glossary" ;
     rdfs:label "Software Quality Assurance Glossary for RSPKMS" ;
     dct:description "SKOS-based glossary of QA, software testing, and agile terms used throughout the RSPKMS." ;
     dct:language "en" ;


### PR DESCRIPTION
## Summary
- fix typos in ontology title string

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a7d15e67483269864fc9bfca22205