### PR TITLE
Add rdflib TTL parsing tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+rdflib
+pytest

--- a/tests/test_parse_ttl.py
+++ b/tests/test_parse_ttl.py
@@ -1,0 +1,11 @@
+import glob
+from rdflib import Graph
+import pytest
+
+# Collect all Turtle files under rdf/ and data/
+ttl_files = glob.glob('rdf/**/*.ttl', recursive=True) + glob.glob('data/**/*.ttl', recursive=True)
+
+@pytest.mark.parametrize('ttl_file', ttl_files)
+def test_parse_ttl_files(ttl_file):
+    g = Graph()
+    g.parse(ttl_file, format='turtle')


### PR DESCRIPTION
## Summary
- add regression test ensuring all `.ttl` files under `rdf/` and `data/` parse
- list test requirements
- fix `test_parse_ttl.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: rdflib.parse errors in TTL files)*

------
https://chatgpt.com/codex/tasks/task_e_686a86b5350c8326bc3c70afc3d9b4b2