### PR TITLE
Add redirect rules for all TTL resources

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,15 +1,23 @@
 RewriteEngine On
 RewriteBase /schweidler/semantics/qa-kg/
 
-# RDF requests (application/rdf+xml or .ttl)
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{REQUEST_URI} \.ttl$
-RewriteRule ^$ https://schweidler.github.io/qa-kg/ontology/qa-upper.ttl [R=302,L]
+# Redirect ontology and vocabulary IRIs to the corresponding Turtle files
+RewriteRule ^upper-ontology/?$ https://schweidler.github.io/qa-kg/ontologies/upper/0.1.0/upper.ttl [R=302,L]
+RewriteRule ^core-glossary/?$ https://schweidler.github.io/qa-kg/glossaries/cross-domain/core-concepts/0.1.0/core-concepts.ttl [R=302,L]
+RewriteRule ^scrum-glossary/?$ https://schweidler.github.io/qa-kg/glossaries/domain/scrum/0.1.0/scrum.ttl [R=302,L]
+RewriteRule ^test-glossary/?$ https://schweidler.github.io/qa-kg/glossaries/domain/software-testing/0.1.0/software-testing.ttl [R=302,L]
+RewriteRule ^meronymy-vocabulary/?$ https://schweidler.github.io/qa-kg/vocabularies/meronymy/0.1.0/meronymy-vocabulary.ttl [R=302,L]
+RewriteRule ^qa-taxonomy/?$ https://schweidler.github.io/qa-kg/taxonomies/qa/0.1.0/qa-taxonomy.ttl [R=302,L]
+RewriteRule ^scrum-vocabulary/?$ https://schweidler.github.io/qa-kg/vocabularies/scrum/0.1.0/scrum-vocabulary.ttl [R=302,L]
+RewriteRule ^org-people-vocabulary/?$ https://schweidler.github.io/qa-kg/vocabularies/org-people/0.1.0/org-people-vocabulary.ttl [R=302,L]
+RewriteRule ^qa-vocabulary/?$ https://schweidler.github.io/qa-kg/vocabularies/qa/0.1.0/qa-vocabulary.ttl [R=302,L]
+RewriteRule ^artifacts-vocabulary/?$ https://schweidler.github.io/qa-kg/vocabularies/artifacts/0.1.0/artifacts-vocabulary.ttl [R=302,L]
+RewriteRule ^manifest/?$ https://schweidler.github.io/qa-kg/manifest.ttl [R=302,L]
+RewriteRule ^data/rene-schweidler/?$ https://schweidler.github.io/qa-kg/data/rene-schweidler.ttl [R=302,L]
+RewriteRule ^data/person-glossary/?$ https://schweidler.github.io/qa-kg/data/person-glossary.ttl [R=302,L]
 
-# HTML documentation
-RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^$ https://schweidler.github.io/qa-kg/ [R=302,L]
+# Serve other .ttl files by mirroring the repository path
+RewriteRule ^(.+\.ttl)$ https://schweidler.github.io/qa-kg/$1 [R=302,L]
 
-# Fallback
+# Default to the GitHub Pages site for all other requests
 Redirect 302 / https://schweidler.github.io/qa-kg/


### PR DESCRIPTION
## Summary
- expand `.htaccess` to redirect every ontology, glossary and vocabulary
  IRI to its Turtle file
- keep a catch‑all rule for any other `.ttl` path
- redirect the rest to the GitHub Pages site

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7cbdd04c83268ad900873de8ce04